### PR TITLE
Express dimensionless units of ice_fraction_xinanjiang and soil_moisture_profile as "1" so UDUNITS2 can parse them (NGWPC-7604)

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -320,8 +320,8 @@ static const char *input_var_units[INPUT_VAR_NAME_COUNT] = {
         "mm h-1", //"atmosphere_water__liquid_equivalent_precipitation_rate"
         "m s-1",   //"water_potential_evaporation_flux"
 	"m",    // ice fraction in meters
-	"none",     // ice fraction [-]
-	"none" // soil moisture profile is in decimal fraction -rlm
+	"1",     // ice fraction [-]
+	"1" // soil moisture profile is in decimal fraction -rlm
 };
 
 static const int input_var_item_count[INPUT_VAR_NAME_COUNT] = {


### PR DESCRIPTION
CFE presently gives units of its input variables `ice_fraction_xinanjiang` and `soil_moisture_profile` as the string `"none"`. Both of these are dimensionless fraction quantities. However, the UDUNITS2 library we use to parse units doesn't parse `"none"` as indicating a dimensionless quantity.

## Changes

- Change `"none"` to `"1"` so that UDUNITS2 understands it as a dimensionless quantity.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: