### PR TITLE
Unit Conversion Error (NGWPC-7604)

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -259,7 +259,7 @@ static const char *output_var_units[OUTPUT_VAR_NAME_COUNT] = {
       	"m",
 	    "m",
 	    "m",
-	    "none",
+	    "1",
 	    "m"
 };
 

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -319,7 +319,7 @@ static const char *input_var_types[INPUT_VAR_NAME_COUNT] = {
 static const char *input_var_units[INPUT_VAR_NAME_COUNT] = {
         "mm h-1", //"atmosphere_water__liquid_equivalent_precipitation_rate"
         "m s-1",   //"water_potential_evaporation_flux"
-	"m",    // ice fraction in meters
+	"1",    // ice fraction should be dimensionless
 	"1",     // ice fraction [-]
 	"1" // soil moisture profile is in decimal fraction -rlm
 };


### PR DESCRIPTION
The UDUNITS package can’t parse "none", which caused warnings like “Unable to parse out_units value none.” Normalizing to "1" matches ngen's convention and avoids spurious conversion errors. This ensures variables defined with “no-units” in realization metadata are recorded as dimensionless from the start, preventing downstream unit-conversion attempts and warnings.

## Changes

Updated cfe/src/bmi_cfe.c 
 - the input units for ice_fraction_schaake are "1" (dimensionless) instead of "m". This aligns with UDUNITS and SFT’s outputs, eliminating “units not convertible/parse none” warnings during CFE↔SFT coupling.
 - nn output_var_units, SURF_RUNOFF_SCHEME is currently "none". If that value is ever consumed by another module, switch it to "1" as well to avoid future UDUNITS parse errors.

## Testing

1. Not seeing the conversion error

