### PR TITLE
Throttle groundwater flux warning message to a single log entry.

### DIFF
--- a/src/cfe.c
+++ b/src/cfe.c
@@ -1,8 +1,11 @@
 #include "cfe.h"
 #include "logger.h"
+#include <stdbool.h>
 
 #define max(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b);  _a > _b ? _a : _b; })
 #define min(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b);  _a < _b ? _a : _b; })
+
+static bool groundwaterFluxIssueLogged = false;
 
 // CFE STATE SPACE FUNCTION // #######################################################################
 // Adapted version of Conceptual Functional Equivalent model re-written in state-space form July, 2021
@@ -242,14 +245,17 @@ extern void cfe(
   
   flux_from_deep_gw_to_chan_m=primary_flux;  // m/h   <<<<<<<<<< BASE FLOW FLUX >>>>>>>>>
   if(flux_from_deep_gw_to_chan_m >  gw_reservoir_struct->storage_m)  {
-  flux_from_deep_gw_to_chan_m=gw_reservoir_struct->storage_m;
-  // TODO: set a flag when flux larger than storage
-  // Adding specific warning message requested by OWP (9/11/2025)
-  Log(WARNING,
-    "Groundwater flux larger than storage. "
-    "While this will not cause a run failure, "
-    "parameter combinations may not be realistic "
-    "and a mass balance error will occur.\n");
+    flux_from_deep_gw_to_chan_m=gw_reservoir_struct->storage_m;
+    // TODO: set a flag when flux larger than storage
+    // Adding specific warning message requested by OWP (9/11/2025)
+    if (!groundwaterFluxIssueLogged) {
+        Log(WARNING,
+            "Groundwater flux larger than storage. "
+            "While this will not cause a run failure, "
+            "parameter combinations may not be realistic "
+            "and a mass balance error will occur.\n");
+        groundwaterFluxIssueLogged = true;
+    }
   }
  
   massbal_struct->vol_from_gw+=flux_from_deep_gw_to_chan_m;


### PR DESCRIPTION
This WARNING log entry was producing the same message thousands of times with no benefit gained after the 1st log entry. Throttled this to a single entry in the log.

## Additions

- Add flag to indicate the groundwater flux warning message log state
- Add if test of flag and if not set, log the entry and set the flag.

## Changes

- Indented block after test for groundwater flux where the log message is generated.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

