### PR TITLE
Get_value Support for "serialization_size" (NGWPC-9616)

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -2115,6 +2115,7 @@ static int Get_value (Bmi *self, const char *name, void *dest)
         cfe_state_struct* model = (cfe_state_struct*)self->data;
         if (model->serialized != NULL) {
             memcpy(dest, &model->serialized_length, sizeof(uint64_t));
+            uint64_t *set_value = (uint64_t *)dest;
             return BMI_SUCCESS;
         }
         return BMI_FAILURE;

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -2115,7 +2115,6 @@ static int Get_value (Bmi *self, const char *name, void *dest)
         cfe_state_struct* model = (cfe_state_struct*)self->data;
         if (model->serialized != NULL) {
             memcpy(dest, &model->serialized_length, sizeof(uint64_t));
-            uint64_t *set_value = (uint64_t *)dest;
             return BMI_SUCCESS;
         }
         return BMI_FAILURE;

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -2111,6 +2111,13 @@ static int Get_value (Bmi *self, const char *name, void *dest)
             return BMI_SUCCESS;
         }
         return BMI_FAILURE;
+    } else if (strcmp(name, "serialization_size") == 0) {
+        cfe_state_struct* model = (cfe_state_struct*)self->data;
+        if (model->serialized != NULL) {
+            memcpy(dest, &model->serialized_length, sizeof(uint64_t));
+            return BMI_SUCCESS;
+        }
+        return BMI_FAILURE;
     }
 
     // Use nested call to "by index" version

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1637,6 +1637,9 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
     } else if (strcmp(name, "serialization_free") == 0) {
         strncpy(type, "int", BMI_MAX_TYPE_NAME);
         return BMI_SUCCESS;
+    } else if (strcmp(name, "reset_time")) {
+        strncpy(type, "double", BMI_MAX_TYPE_NAME);
+        return BMI_SUCCESS;
     }
 
     // If we get here, it means the variable name wasn't recognized
@@ -1751,6 +1754,9 @@ static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
         return BMI_SUCCESS;
     } else if (strcmp(name, "serialization_free") == 0) {
         *nbytes = sizeof(int);
+        return BMI_SUCCESS;
+    } else if (strcmp(name, "reset_time") == 0) {
+        *nbytes = sizeof(double);
         return BMI_SUCCESS;
     }
     int item_size;
@@ -2165,6 +2171,11 @@ static int Set_value (Bmi *self, const char *name, void *src)
         return new_serialized_cfe(self);
     } else if (strcmp(name, "serialization_free") == 0) {
         return free_serialized_cfe(self);
+    } else if (strcmp(name, "reset_time") == 0) {
+        cfe_state_struct *model = (cfe_state_struct *)self->data;
+        // time step only used for indexing into forcing data during update
+        model->current_time_step = 0;
+        return BMI_SUCCESS;
     }
     // Avoid using set value, call instead set_value_at_index
     // Use nested call to "by index" version


### PR DESCRIPTION
Using `Get_value` was for `"serialization_size"` was not configured correctly.

## Additions

- `"serialization_size"` check on the `Get_value` function.
- `"reset_time"` message in `Set_value` to set the BMI's time to 0


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
