### PR TITLE
Merge Changes on OWP Mater Branch with Development (NGWPC-9801)

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1176,6 +1176,8 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
     else {
       model->soil_reservoir.is_aet_rootzone = FALSE;
       model->soil_reservoir.n_soil_layers   = 1;
+      model->soil_reservoir.soil_layer_depths_m = NULL;
+      model->soil_reservoir.delta_soil_layer_depth_m = NULL;
     }
 
     /*--------------------END OF ROOT ZONE ADJUSTED AET DEVELOPMENT -rlm ------------------------------*/
@@ -1367,6 +1369,11 @@ static int Initialize (Bmi *self, const char *file)
     cfe_bmi_data_ptr->gw_reservoir.coeff_secondary = 0.0;                // 0.0 means that secondary outlet is not applied
     cfe_bmi_data_ptr->gw_reservoir.exponent_secondary = 1.0;             // linear
 
+    // Not used in gw reservoir
+    cfe_bmi_data_ptr->gw_reservoir.smc_profile = NULL;
+    cfe_bmi_data_ptr->gw_reservoir.soil_layer_depths_m = NULL;
+    cfe_bmi_data_ptr->gw_reservoir.delta_soil_layer_depth_m = NULL;
+
     // Initialize soil conceptual reservoirs
     //LKC Remove alpha_fc
     init_soil_reservoir(cfe_bmi_data_ptr);
@@ -1512,7 +1519,10 @@ static int Finalize (Bmi *self)
             free(model->forcing_data_precip_kg_per_m2);
         if( model->forcing_data_time != NULL )
             free(model->forcing_data_time);
-        
+        if( model->forcing_file != NULL ){
+            free(model->forcing_file);
+        }
+
         if( model->giuh_ordinates != NULL )
             free(model->giuh_ordinates);
         if( model->nash_storage_subsurface != NULL )
@@ -1521,7 +1531,10 @@ static int Finalize (Bmi *self)
             free(model->runoff_queue_m_per_timestep);
         if( model->flux_Qout_m != NULL )
             free(model->flux_Qout_m);
-        
+
+        if( model->soil_reservoir.smc_profile != NULL )
+            free(model->soil_reservoir.smc_profile);
+
         /* xinanjiang_dev: changing name to the more general "direct runoff"
         if( model->flux_Schaake_output_runoff_m != NULL )
             free(model->flux_Schaake_output_runoff_m);*/
@@ -3187,6 +3200,7 @@ extern void init_soil_reservoir(cfe_state_struct* cfe_ptr)
 }*/
 
 extern void initialize_volume_trackers(cfe_state_struct* cfe_ptr) {
+    cfe_ptr->vol_struct.volstart         = 0.0;
     cfe_ptr->vol_struct.volin            = 0;
     cfe_ptr->vol_struct.vol_runoff       = 0;
     cfe_ptr->vol_struct.vol_infilt       = 0;


### PR DESCRIPTION
Merge changes made on the parent NOAA-OWP CFE `master` branch with the current `development` branch.

The changes coming in were for freeing data potentially created during BMI initialization and setting data pointers to `NULL` when the BMI's backing model is created. The frees are being incorporated, but the `NULL` sets were rejected. Previously in NGWPC, the `malloc` call had been changed to `calloc` to ensure all pointers started as `NULL`, so explicitly setting the pointers to `NULL` is no longer needed.

## Additions

- Additional pointers `free`'d and set to `NULL` when `Finalize` is called on the BMI.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
