### PR TITLE
Having Consistent RainMelt Value for all Runoff Models: CFE

### DIFF
--- a/realizations/realization_cfe_pet.json
+++ b/realizations/realization_cfe_pet.json
@@ -20,7 +20,8 @@
 			"POTENTIAL_ET",
 			"ACTUAL_ET",
 			"SOIL_STORAGE",
-			"NWM_PONDED_DEPTH"
+			"NWM_PONDED_DEPTH",
+			"atmosphere_water__liquid_equivalent_precipitation_rate_out"
 		    ],
                     "modules": [
 			{

--- a/realizations/realization_cfe_pet_surfnash.json
+++ b/realizations/realization_cfe_pet_surfnash.json
@@ -20,7 +20,8 @@
 			"POTENTIAL_ET",
 			"ACTUAL_ET",
 			"SOIL_STORAGE",
-			"NWM_PONDED_DEPTH"
+			"NWM_PONDED_DEPTH",
+			"atmosphere_water__liquid_equivalent_precipitation_rate_out"
 		    ],
                     "modules": [
 			{

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -23,7 +23,7 @@
 #define CFE_DEBUG 0
 
 #define INPUT_VAR_NAME_COUNT 5
-#define OUTPUT_VAR_NAME_COUNT 15
+#define OUTPUT_VAR_NAME_COUNT 16
 
 #define STATE_VAR_NAME_COUNT 95   // must match var_info array size
 
@@ -206,7 +206,8 @@ static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = {
         "SOIL_STORAGE",
         "SOIL_STORAGE_CHANGE",
         "SURF_RUNOFF_SCHEME",
-	    "NWM_PONDED_DEPTH"
+	"NWM_PONDED_DEPTH",
+	"atmosphere_water__liquid_equivalent_precipitation_rate_out"
 };
 
 static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
@@ -224,6 +225,7 @@ static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
 	    "double",
         "double",
 	    "int",
+	    "double",
 	    "double"
 };
 
@@ -240,6 +242,7 @@ static const int output_var_item_count[OUTPUT_VAR_NAME_COUNT] = {
         1,
         1,
         1,
+	    1,
 	    1,
 	    1,
 	    1
@@ -260,7 +263,8 @@ static const char *output_var_units[OUTPUT_VAR_NAME_COUNT] = {
 	    "m",
 	    "m",
 	    "1",
-	    "m"
+	    "m",
+	    "mm h-1"
 };
 
 static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
@@ -278,7 +282,8 @@ static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
         0,
         0,
         0,
-        0
+        0,
+	0
 };
 
 static const char *output_var_locations[OUTPUT_VAR_NAME_COUNT] = {
@@ -296,7 +301,9 @@ static const char *output_var_locations[OUTPUT_VAR_NAME_COUNT] = {
         "node",
 	"node",
 	"none",
-	"node"
+	"node",
+        "node"
+
 };
 
 // Don't forget to update Get_value/Get_value_at_indices (and setter) implementation if these are adjusted
@@ -2026,6 +2033,14 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
       *dest = (void*)&cfe_ptr->nwm_ponded_depth_m;
       return BMI_SUCCESS;
     }
+
+    if (strcmp(name, "atmosphere_water__liquid_equivalent_precipitation_rate_out") == 0) {
+      cfe_state_struct *cfe_ptr;
+      cfe_ptr = (cfe_state_struct *) self->data;
+      *dest = (void*)&cfe_ptr->aorc.precip_kg_per_m2;
+      return BMI_SUCCESS;
+    }
+
     /***********************************************************/
     /***********    INPUT    ***********************************/
     /***********************************************************/


### PR DESCRIPTION
Based on story: https://jira.nextgenwaterprediction.com/browse/NGWPC-9963.
Review and update as necessary the rainfall runoff models (CFE, LASAM, TOPMODEL, SAC-SMA) to assure they are generating consistent output of liquid water input in a consistent output variable that can be converted to appropriate units for display in ngenCERF

Coordinate as needed with MSWM configurations. 


-

## Changes

Added output variable atmosphere_water__liquid_equivalent_precipitation_rate_out to pass input atmosphere_water__liquid_equivalent_precipitation_rate 

## Testing

https://confluence.nextgenwaterprediction.com/spaces/NGWPC/pages/90177659/RR+models+Consistent+rain+melt+Output#RRmodelsConsistentrain+meltOutput-CFE

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
