### PR TITLE
update CFE DEEP_GW_TO_CHANNEL_FLUX unit

### DIFF
--- a/include/bmi_cfe.h
+++ b/include/bmi_cfe.h
@@ -106,6 +106,14 @@ struct cfe_state_struct {
     double* flux_direct_runoff_m;
     double* flux_nash_lateral_runoff_m;
     double* flux_from_deep_gw_to_chan_m;
+
+    /* BMI-facing converted qBucket value:
+     * CFE internal deep groundwater flux is m/timestep.
+     * NWM expects DEEP_GW_TO_CHANNEL_FLUX in m3/s.
+     */
+    double flux_from_deep_gw_to_chan_m3_per_s;
+    double catchment_area_m2;
+
     double* flux_perc_m;
     double* flux_lat_m;
     double* flux_Qout_m;

--- a/include/bmi_cfe.h
+++ b/include/bmi_cfe.h
@@ -88,6 +88,7 @@ struct cfe_state_struct {
     int surface_runoff_scheme;   // options: giuh-based runoff and nash cascade-based runoff
 
     double nwm_ponded_depth_m;
+    double sfcrnoff_accum_m;
     // ***********************************************************
     // ******************* Dynamic allocations *******************
     // ***********************************************************

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -23,7 +23,7 @@
 #define CFE_DEBUG 0
 
 #define INPUT_VAR_NAME_COUNT 5
-#define OUTPUT_VAR_NAME_COUNT 17
+#define OUTPUT_VAR_NAME_COUNT 18
 
 #define STATE_VAR_NAME_COUNT 95   // must match var_info array size
 
@@ -208,7 +208,8 @@ static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = {
         "SURF_RUNOFF_SCHEME",
 	"NWM_PONDED_DEPTH",
 	"atmosphere_water__liquid_equivalent_precipitation_rate_out",
-	"DEEP_GW_TO_CHANNEL_FLUX_M3_PER_S"
+	"DEEP_GW_TO_CHANNEL_FLUX_M3_PER_S",
+	"SFCRNOFF",
 };
 
 static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
@@ -228,6 +229,7 @@ static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
 	    "int",
 	    "double",
 	    "double",
+	    "double",
 	    "double"
 };
 
@@ -244,6 +246,7 @@ static const int output_var_item_count[OUTPUT_VAR_NAME_COUNT] = {
         1,
         1,
         1,
+	    1,
 	    1,
 	    1,
 	    1,
@@ -268,7 +271,8 @@ static const char *output_var_units[OUTPUT_VAR_NAME_COUNT] = {
 	    "1",
 	    "m",
 	    "mm h-1",
-	    "m3 s-1"
+	    "m3 s-1",
+	    "m"
 };
 
 static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
@@ -287,6 +291,7 @@ static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
         0,
         0,
         0,
+	0,
 	0,
 	0
 };
@@ -308,6 +313,7 @@ static const char *output_var_locations[OUTPUT_VAR_NAME_COUNT] = {
 	"none",
 	"node",
         "node",
+	"node",
 	"node"
 
 };
@@ -1303,6 +1309,8 @@ static int Initialize (Bmi *self, const char *file)
     //This needs an initial value, it is used in computations in CFE and only set towards the end of the model
     //See issue #31
     *cfe_bmi_data_ptr->flux_perc_m = 0.0;
+    /* sfcrnoff_accum_m is a scalar (not a pointer), so no allocation is needed */
+    cfe_bmi_data_ptr->sfcrnoff_accum_m = 0.0;
 
 
     /*******************************************************
@@ -1462,7 +1470,15 @@ static int Update (Bmi *self)
     cfe_ptr->vol_struct.volin += cfe_ptr->timestep_rainfall_input_m;
     
     run_cfe(cfe_ptr);
-        
+
+    /* Accumulated surface runoff depth for NWM SFCRNOFF.
+     * Using direct runoff only; not including Nash lateral flow unless confirmed.
+     */
+
+    if (cfe_ptr->flux_direct_runoff_m != NULL) {
+      cfe_ptr->sfcrnoff_accum_m += *(cfe_ptr->flux_direct_runoff_m);
+    }
+
     // Advance the model time 
     cfe_ptr->current_time_step += 1;
 
@@ -2073,6 +2089,13 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
       *dest = (void*)&cfe_ptr->aorc.precip_kg_per_m2;
       return BMI_SUCCESS;
     }
+
+    if (strcmp(name, "SFCRNOFF") == 0) {
+      cfe_state_struct *cfe_ptr;
+      cfe_ptr = (cfe_state_struct *) self->data;
+      *dest = (void *)&cfe_ptr->sfcrnoff_accum_m;
+      return BMI_SUCCESS;
+}
 
     /***********************************************************/
     /***********    INPUT    ***********************************/
@@ -3075,6 +3098,7 @@ cfe_state_struct *new_bmi_cfe(void)
     data->time_step_size                = 3600;
     data->time_step_fraction            = 1.0;
     data->flux_from_deep_gw_to_chan_m3_per_s = 0.0;
+    data->sfcrnoff_accum_m               = 0.0;
     data->catchment_area_m2             = 0.0;
 
     return data;

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -208,7 +208,7 @@ static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = {
         "SURF_RUNOFF_SCHEME",
 	"NWM_PONDED_DEPTH",
 	"atmosphere_water__liquid_equivalent_precipitation_rate_out",
-	"DEEP_GW_TO_CHANNEL_FLUX_M3_PER_S",
+	"DEEP_GW_TO_CHANNEL_FLUX_M3_PER_S"
 };
 
 static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -254,7 +254,7 @@ static const char *output_var_units[OUTPUT_VAR_NAME_COUNT] = {
         "m",
         "m",
         "m",
-        "m",
+        "m3 s-1",
         "m",
         "m",
         "m",
@@ -1978,6 +1978,19 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
     }
 
     if (strcmp (name, "DEEP_GW_TO_CHANNEL_FLUX") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+
+        cfe_ptr->flux_from_deep_gw_to_chan_m3_per_s =
+            (*(cfe_ptr->flux_from_deep_gw_to_chan_m) *
+             cfe_ptr->catchment_area_m2) /
+            (double)cfe_ptr->time_step_size;
+
+        *dest = (void *)&cfe_ptr->flux_from_deep_gw_to_chan_m3_per_s;
+        return BMI_SUCCESS;
+    }
+
+    if (strcmp (name, "DEEP_GW_TO_CHANNEL_FLUX") == 0) {
         *dest = (void *) ((cfe_state_struct *)(self->data))->flux_from_deep_gw_to_chan_m;
         return BMI_SUCCESS;
     }
@@ -3042,13 +3055,14 @@ int read_file_line_counts_cfe(const char* file_name, int* line_count, int* max_l
     return 0;
 }
 
-
 cfe_state_struct *new_bmi_cfe(void)
 {
     cfe_state_struct *data;
     data = (cfe_state_struct *) calloc(1, sizeof(cfe_state_struct));
     data->time_step_size                = 3600;
     data->time_step_fraction            = 1.0;
+    data->flux_from_deep_gw_to_chan_m3_per_s = 0.0;
+    data->catchment_area_m2             = 1.0;
 
     return data;
 }

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -23,7 +23,7 @@
 #define CFE_DEBUG 0
 
 #define INPUT_VAR_NAME_COUNT 5
-#define OUTPUT_VAR_NAME_COUNT 16
+#define OUTPUT_VAR_NAME_COUNT 17
 
 #define STATE_VAR_NAME_COUNT 95   // must match var_info array size
 
@@ -207,7 +207,8 @@ static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = {
         "SOIL_STORAGE_CHANGE",
         "SURF_RUNOFF_SCHEME",
 	"NWM_PONDED_DEPTH",
-	"atmosphere_water__liquid_equivalent_precipitation_rate_out"
+	"atmosphere_water__liquid_equivalent_precipitation_rate_out",
+	"DEEP_GW_TO_CHANNEL_FLUX_M3_PER_S",
 };
 
 static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
@@ -225,6 +226,7 @@ static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
 	    "double",
         "double",
 	    "int",
+	    "double",
 	    "double",
 	    "double"
 };
@@ -245,6 +247,7 @@ static const int output_var_item_count[OUTPUT_VAR_NAME_COUNT] = {
 	    1,
 	    1,
 	    1,
+	    1,
 	    1
 };
 
@@ -254,7 +257,7 @@ static const char *output_var_units[OUTPUT_VAR_NAME_COUNT] = {
         "m",
         "m",
         "m",
-        "m3 s-1",
+        "m",
         "m",
         "m",
         "m",
@@ -264,7 +267,8 @@ static const char *output_var_units[OUTPUT_VAR_NAME_COUNT] = {
 	    "m",
 	    "1",
 	    "m",
-	    "mm h-1"
+	    "mm h-1",
+	    "m3 s-1"
 };
 
 static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
@@ -283,6 +287,7 @@ static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
         0,
         0,
         0,
+	0,
 	0
 };
 
@@ -302,7 +307,8 @@ static const char *output_var_locations[OUTPUT_VAR_NAME_COUNT] = {
 	"node",
 	"none",
 	"node",
-        "node"
+        "node",
+	"node"
 
 };
 
@@ -1978,6 +1984,11 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
     }
 
     if (strcmp (name, "DEEP_GW_TO_CHANNEL_FLUX") == 0) {
+        *dest = (void *) ((cfe_state_struct *)(self->data))->flux_from_deep_gw_to_chan_m;
+        return BMI_SUCCESS;
+    }
+
+    if (strcmp (name, "DEEP_GW_TO_CHANNEL_FLUX_M3_PER_S") == 0) {
         cfe_state_struct *cfe_ptr;
         cfe_ptr = (cfe_state_struct *) self->data;
 
@@ -1987,11 +1998,6 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
             (double)cfe_ptr->time_step_size;
 
         *dest = (void *)&cfe_ptr->flux_from_deep_gw_to_chan_m3_per_s;
-        return BMI_SUCCESS;
-    }
-
-    if (strcmp (name, "DEEP_GW_TO_CHANNEL_FLUX") == 0) {
-        *dest = (void *) ((cfe_state_struct *)(self->data))->flux_from_deep_gw_to_chan_m;
         return BMI_SUCCESS;
     }
 

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1992,10 +1992,17 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         cfe_state_struct *cfe_ptr;
         cfe_ptr = (cfe_state_struct *) self->data;
 
-        cfe_ptr->flux_from_deep_gw_to_chan_m3_per_s =
-            (*(cfe_ptr->flux_from_deep_gw_to_chan_m) *
-             cfe_ptr->catchment_area_m2) /
-            (double)cfe_ptr->time_step_size;
+        if (cfe_ptr->flux_from_deep_gw_to_chan_m != NULL &&
+            cfe_ptr->catchment_area_m2 > 0.0 &&
+            cfe_ptr->time_step_size > 0) {
+            cfe_ptr->flux_from_deep_gw_to_chan_m3_per_s =
+                (*(cfe_ptr->flux_from_deep_gw_to_chan_m) *
+                 cfe_ptr->catchment_area_m2) /
+                (double)cfe_ptr->time_step_size;
+        }
+        else {
+            cfe_ptr->flux_from_deep_gw_to_chan_m3_per_s = 0.0;
+        }
 
         *dest = (void *)&cfe_ptr->flux_from_deep_gw_to_chan_m3_per_s;
         return BMI_SUCCESS;
@@ -3068,7 +3075,7 @@ cfe_state_struct *new_bmi_cfe(void)
     data->time_step_size                = 3600;
     data->time_step_fraction            = 1.0;
     data->flux_from_deep_gw_to_chan_m3_per_s = 0.0;
-    data->catchment_area_m2             = 1.0;
+    data->catchment_area_m2             = 0.0;
 
     return data;
 }


### PR DESCRIPTION

https://jira.nextgenwaterprediction.com/browse/NGWPC-10212

**Issue**

DEEP_GW_TO_CHANNEL_FLUX was originally exposed in m (depth per timestep), while NWM expects m³/s (discharge) for qBucket, causing: Unable to convert m to m3/s

**Fix**

Instead of changing the existing variable, a new BMI output variable was introduced:

DEEP_GW_TO_CHANNEL_FLUX_M3_PER_S → m³/s

Computed as:

q = depth × catchment_area / timestep

The original variable remains unchanged:

DEEP_GW_TO_CHANNEL_FLUX → m

**Why**
Preserves model-native semantics (depth remains depth)
Avoids renaming or repurposing existing variables
Aligns with NWM requirement for discharge (qBucket)
Follows consistent BMI design used across modules

**Result**

Eliminates unit conversion warning
Provides physically correct discharge output
Maintains backward compatibility and clarity

**Final Mapping**
Variable	Meaning	Units
DEEP_GW_TO_CHANNEL_FLUX	baseflow depth	m
DEEP_GW_TO_CHANNEL_FLUX_M3_PER_S	baseflow discharge (NWM qBucket)	m³/s