### PR TITLE
output var SFCRNOFF

### DIFF
--- a/include/bmi_cfe.h
+++ b/include/bmi_cfe.h
@@ -88,6 +88,7 @@ struct cfe_state_struct {
     int surface_runoff_scheme;   // options: giuh-based runoff and nash cascade-based runoff
 
     double nwm_ponded_depth_m;
+    double sfcrnoff_accum_m;
     // ***********************************************************
     // ******************* Dynamic allocations *******************
     // ***********************************************************

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -23,7 +23,7 @@
 #define CFE_DEBUG 0
 
 #define INPUT_VAR_NAME_COUNT 5
-#define OUTPUT_VAR_NAME_COUNT 17
+#define OUTPUT_VAR_NAME_COUNT 18
 
 #define STATE_VAR_NAME_COUNT 95   // must match var_info array size
 
@@ -209,6 +209,7 @@ static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = {
 	"NWM_PONDED_DEPTH",
 	"atmosphere_water__liquid_equivalent_precipitation_rate_out",
 	"DEEP_GW_TO_CHANNEL_FLUX_M3_PER_S",
+	"SFCRNOFF",
 };
 
 static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
@@ -228,6 +229,7 @@ static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
 	    "int",
 	    "double",
 	    "double",
+	    "double",
 	    "double"
 };
 
@@ -244,6 +246,7 @@ static const int output_var_item_count[OUTPUT_VAR_NAME_COUNT] = {
         1,
         1,
         1,
+	    1,
 	    1,
 	    1,
 	    1,
@@ -268,7 +271,8 @@ static const char *output_var_units[OUTPUT_VAR_NAME_COUNT] = {
 	    "1",
 	    "m",
 	    "mm h-1",
-	    "m3 s-1"
+	    "m3 s-1",
+	    "m"
 };
 
 static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
@@ -287,6 +291,7 @@ static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
         0,
         0,
         0,
+	0,
 	0,
 	0
 };
@@ -308,6 +313,7 @@ static const char *output_var_locations[OUTPUT_VAR_NAME_COUNT] = {
 	"none",
 	"node",
         "node",
+	"node",
 	"node"
 
 };
@@ -1303,6 +1309,8 @@ static int Initialize (Bmi *self, const char *file)
     //This needs an initial value, it is used in computations in CFE and only set towards the end of the model
     //See issue #31
     *cfe_bmi_data_ptr->flux_perc_m = 0.0;
+    //cfe_bmi_data_ptr->sfcrnoff_accum_m = malloc(sizeof(double));
+    cfe_bmi_data_ptr->sfcrnoff_accum_m = 0.0;
 
 
     /*******************************************************
@@ -1462,7 +1470,15 @@ static int Update (Bmi *self)
     cfe_ptr->vol_struct.volin += cfe_ptr->timestep_rainfall_input_m;
     
     run_cfe(cfe_ptr);
-        
+
+    /* Accumulated surface runoff depth for NWM SFCRNOFF.
+     * Using direct runoff only; not including Nash lateral flow unless confirmed.
+     */
+
+    if (cfe_ptr->flux_direct_runoff_m != NULL) {
+      cfe_ptr->sfcrnoff_accum_m += *(cfe_ptr->flux_direct_runoff_m);
+    }
+
     // Advance the model time 
     cfe_ptr->current_time_step += 1;
 
@@ -2066,6 +2082,13 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
       *dest = (void*)&cfe_ptr->aorc.precip_kg_per_m2;
       return BMI_SUCCESS;
     }
+
+    if (strcmp(name, "SFCRNOFF") == 0) {
+      cfe_state_struct *cfe_ptr;
+      cfe_ptr = (cfe_state_struct *) self->data;
+      *dest = (void *)&cfe_ptr->sfcrnoff_accum_m;
+      return BMI_SUCCESS;
+}
 
     /***********************************************************/
     /***********    INPUT    ***********************************/
@@ -3069,6 +3092,7 @@ cfe_state_struct *new_bmi_cfe(void)
     data->time_step_fraction            = 1.0;
     data->flux_from_deep_gw_to_chan_m3_per_s = 0.0;
     data->catchment_area_m2             = 1.0;
+    data->sfcrnoff_accum_m               = 0.0;
 
     return data;
 }

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1309,7 +1309,7 @@ static int Initialize (Bmi *self, const char *file)
     //This needs an initial value, it is used in computations in CFE and only set towards the end of the model
     //See issue #31
     *cfe_bmi_data_ptr->flux_perc_m = 0.0;
-    //cfe_bmi_data_ptr->sfcrnoff_accum_m = malloc(sizeof(double));
+    /* sfcrnoff_accum_m is a scalar (not a pointer), so no allocation is needed */
     cfe_bmi_data_ptr->sfcrnoff_accum_m = 0.0;
 
 


### PR DESCRIPTION
https://jira.nextgenwaterprediction.com/browse/NGWPC-10633

**Issue**

The NWM requires an accumulated surface runoff variable (SFCRNOFF), but CFE did not expose a corresponding output through the BMI. Existing variables such as DIRECT_RUNOFF and NASH_LATERAL_RUNOFF were available, but no accumulated surface runoff output was provided.

**Fix**

A new BMI output variable was introduced: SFCRNOFF → m

This variable is computed by accumulating direct surface runoff over time:

SFCRNOFF = Σ (DIRECT_RUNOFF per timestep)

The value is updated during each model Update() call and exposed through the BMI.

**Why**
Provides the missing NWM-required accumulated surface runoff output
Preserves existing CFE variables without altering their meaning
Avoids mixing surface runoff with lateral/subsurface flow
Aligns with expected NWM variable definitions

**Result**
Enables CFE to supply SFCRNOFF to NWM workflows
Maintains clarity between different runoff components
Supports consistent cross-model output integration
