### PR TITLE
added checking and logging for nan input

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1008,7 +1008,7 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
             else if (gw_bad_param_warned == 1) {
                 Log(WARNING,
                     "Invalid CFE groundwater reservoir parameters occurred again; "
-                    "further warnings suppressed.\n");
+                    "subsequent occurrences of this message will be suppressed.\n");
 
                 gw_bad_param_warned = 2;
             }

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -981,6 +981,8 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
     }
     
     // compute gw storage in meters
+    static int gw_bad_param_warned = 0;
+
     if ((is_gw_storage_set == TRUE) && (is_gw_max_set == TRUE)) {
         if (!isfinite(model->gw_reservoir.gw_storage) ||
             !isfinite(model->gw_reservoir.storage_max_m) ||
@@ -989,15 +991,26 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
             model->gw_reservoir.gw_storage < 0.0 ||
             model->gw_reservoir.storage_max_m <= 0.0) {
 
-            Log(WARNING,
-                "Invalid CFE groundwater reservoir parameters from config; "
-                "disabling groundwater reservoir and setting DEEP_GW_TO_CHANNEL_FLUX to 0. "
-                "gw_storage=%lf, max_gw_storage=%lf, Cgw=%lf, expon=%lf. "
-                "This is likely an upstream NHF parameter-generation issue.\n",
-                model->gw_reservoir.gw_storage,
-                model->gw_reservoir.storage_max_m,
-                model->gw_reservoir.coeff_primary,
-                model->gw_reservoir.exponent_primary);
+            if (gw_bad_param_warned == 0) {
+                Log(WARNING,
+                    "Invalid CFE groundwater reservoir parameters from config; "
+                    "disabling groundwater reservoir and setting DEEP_GW_TO_CHANNEL_FLUX to 0. "
+                    "gw_storage=%lf, max_gw_storage=%lf, Cgw=%lf, expon=%lf. "
+                    "This is likely an upstream NHF parameter-generation issue.\n",
+                    model->gw_reservoir.gw_storage,
+                    model->gw_reservoir.storage_max_m,
+                    model->gw_reservoir.coeff_primary,
+                    model->gw_reservoir.exponent_primary);
+
+                gw_bad_param_warned = 1;
+            }
+            else if (gw_bad_param_warned == 1) {
+                Log(WARNING,
+                    "Invalid CFE groundwater reservoir parameters occurred again; "
+                    "further warnings suppressed.\n");
+
+                gw_bad_param_warned = 2;
+            }
 
             model->gw_reservoir.gw_storage = 0.0;
             model->gw_reservoir.storage_max_m = 0.0;

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -2269,11 +2269,27 @@ static int Set_value_at_indices (Bmi *self, const char *name, int * inds, int le
     if (self->get_var_itemsize(self, name, &itemsize) == BMI_FAILURE)
         return BMI_FAILURE;
 
+    if (strcmp(name, "water_potential_evaporation_flux") == 0) {
+        for (size_t i=0; i<len; i++) {
+            double potential_et_m_per_s = *(((double*)src) + i);
+
+            if (!isfinite(potential_et_m_per_s) ||
+                potential_et_m_per_s < 0.0) {
+                Log(FATAL,
+                    "Invalid water_potential_evaporation_flux passed to CFE Set_value_at_indices: %lf. "
+                    "PET forcing must be finite and non-negative. Aborting...\n",
+                    potential_et_m_per_s);
+
+                return BMI_FAILURE;
+            }
+        }
+    }
+
     size_t i;
     size_t offset;
     char * ptr;
     // iterate over the source pointer, src, by itemsize byte chunks
-    // and set the destination pointer, dest, to the value in src 
+    // and set the destination pointer, dest, to the value in src
     // based on the linear offset provided by inds[i]
     for (i=0, ptr=(char*)src; i<len; i++, ptr+=itemsize) {
       offset = inds[i] * itemsize;

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -976,13 +976,12 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
         return BMI_FAILURE;
     }
     if (is_gw_storage_set == FALSE) {
-        Log(SEVERE, "Config param 'gw_storage' not found in config file. Aborting...n");
+	Log(SEVERE, "Config param 'gw_storage' not found in config file. Aborting...\n");
         return BMI_FAILURE;
     }
     
     // compute gw storage in meters
-    static int gw_bad_param_warned = 0;
-
+    // compute gw storage in meters
     // compute gw storage in meters
     if ((is_gw_storage_set == TRUE) && (is_gw_max_set == TRUE)) {
         if (!isfinite(model->gw_reservoir.gw_storage) ||
@@ -995,11 +994,10 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
             static int gw_bad_param_warned = 0;
 
             if (gw_bad_param_warned == 0) {
-                Log(SEVERE,
+                Log(WARNING,
                     "Invalid CFE groundwater reservoir parameters from config. "
                     "gw_storage=%lf, max_gw_storage=%lf, Cgw=%lf, expon=%lf. "
-                    "CFE cannot initialize groundwater reservoir with non-finite or physically invalid required values. "
-                    "Please check upstream parameter generation.",
+                    "This indicates an upstream parameter-generation issue that should be corrected.\n",
                     model->gw_reservoir.gw_storage,
                     model->gw_reservoir.storage_max_m,
                     model->gw_reservoir.coeff_primary,
@@ -1008,14 +1006,12 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
                 gw_bad_param_warned = 1;
             }
             else if (gw_bad_param_warned == 1) {
-                Log(SEVERE,
+                Log(WARNING,
                     "Invalid CFE groundwater reservoir parameters occurred again; "
-                    "subsequent occurrences of this message will be suppressed.");
+                    "further warnings suppressed.\n");
 
                 gw_bad_param_warned = 2;
             }
-
-            return BMI_FAILURE;
         }
 
         model->gw_reservoir.storage_m =
@@ -2269,27 +2265,11 @@ static int Set_value_at_indices (Bmi *self, const char *name, int * inds, int le
     if (self->get_var_itemsize(self, name, &itemsize) == BMI_FAILURE)
         return BMI_FAILURE;
 
-    if (strcmp(name, "water_potential_evaporation_flux") == 0) {
-        for (size_t i=0; i<len; i++) {
-            double potential_et_m_per_s = *(((double*)src) + i);
-
-            if (!isfinite(potential_et_m_per_s) ||
-                potential_et_m_per_s < 0.0) {
-                Log(FATAL,
-                    "Invalid water_potential_evaporation_flux passed to CFE Set_value_at_indices: %lf. "
-                    "PET forcing must be finite and non-negative. Aborting...\n",
-                    potential_et_m_per_s);
-
-                return BMI_FAILURE;
-            }
-        }
-    }
-
     size_t i;
     size_t offset;
     char * ptr;
     // iterate over the source pointer, src, by itemsize byte chunks
-    // and set the destination pointer, dest, to the value in src
+    // and set the destination pointer, dest, to the value in src 
     // based on the linear offset provided by inds[i]
     for (i=0, ptr=(char*)src; i<len; i++, ptr+=itemsize) {
       offset = inds[i] * itemsize;
@@ -2299,7 +2279,6 @@ static int Set_value_at_indices (Bmi *self, const char *name, int * inds, int le
     return BMI_SUCCESS;
 
 }
-
 
 static int Set_value (Bmi *self, const char *name, void *src)
 {
@@ -2330,20 +2309,6 @@ static int Set_value (Bmi *self, const char *name, void *src)
 
     if (self->get_var_nbytes(self, name, &nbytes) == BMI_FAILURE)
         return BMI_FAILURE;
-
-    if (strcmp(name, "water_potential_evaporation_flux") == 0) {
-        double potential_et_m_per_s = *((double*)src);
-
-        if (!isfinite(potential_et_m_per_s) ||
-            potential_et_m_per_s < 0.0) {
-            Log(FATAL,
-                "Invalid water_potential_evaporation_flux passed to CFE Set_value: %lf. "
-                "PET forcing must be finite and non-negative. Aborting...\n",
-                potential_et_m_per_s);
-
-            return BMI_FAILURE;
-        }
-    }
 
     memcpy (dest, src, nbytes);
 

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -983,6 +983,7 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
     // compute gw storage in meters
     static int gw_bad_param_warned = 0;
 
+    // compute gw storage in meters
     if ((is_gw_storage_set == TRUE) && (is_gw_max_set == TRUE)) {
         if (!isfinite(model->gw_reservoir.gw_storage) ||
             !isfinite(model->gw_reservoir.storage_max_m) ||
@@ -991,12 +992,14 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
             model->gw_reservoir.gw_storage < 0.0 ||
             model->gw_reservoir.storage_max_m <= 0.0) {
 
+            static int gw_bad_param_warned = 0;
+
             if (gw_bad_param_warned == 0) {
-                Log(WARNING,
-                    "Invalid CFE groundwater reservoir parameters from config; "
-                    "disabling groundwater reservoir and setting DEEP_GW_TO_CHANNEL_FLUX to 0. "
+                Log(SEVERE,
+                    "Invalid CFE groundwater reservoir parameters from config. "
                     "gw_storage=%lf, max_gw_storage=%lf, Cgw=%lf, expon=%lf. "
-                    "This is likely an upstream NHF parameter-generation issue.\n",
+                    "CFE cannot initialize groundwater reservoir with non-finite or physically invalid required values. "
+                    "Please check upstream parameter generation.\n",
                     model->gw_reservoir.gw_storage,
                     model->gw_reservoir.storage_max_m,
                     model->gw_reservoir.coeff_primary,
@@ -1005,24 +1008,19 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
                 gw_bad_param_warned = 1;
             }
             else if (gw_bad_param_warned == 1) {
-                Log(WARNING,
+                Log(SEVERE,
                     "Invalid CFE groundwater reservoir parameters occurred again; "
                     "further warnings suppressed.\n");
 
                 gw_bad_param_warned = 2;
             }
 
-            model->gw_reservoir.gw_storage = 0.0;
-            model->gw_reservoir.storage_max_m = 0.0;
-            model->gw_reservoir.storage_m = 0.0;
-            model->gw_reservoir.coeff_primary = 0.0;
-            model->gw_reservoir.exponent_primary = 1.0;
+            return BMI_FAILURE;
         }
-        else {
-            model->gw_reservoir.storage_m =
-                model->gw_reservoir.gw_storage *
-                model->gw_reservoir.storage_max_m;
-        }
+
+        model->gw_reservoir.storage_m =
+            model->gw_reservoir.gw_storage *
+            model->gw_reservoir.storage_max_m;
     }
 
     if (is_num_timesteps_set == FALSE && strcmp(model->forcing_file, "BMI")) {

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -981,8 +981,6 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
     }
     
     // compute gw storage in meters
-    // compute gw storage in meters
-    // compute gw storage in meters
     if ((is_gw_storage_set == TRUE) && (is_gw_max_set == TRUE)) {
         if (!isfinite(model->gw_reservoir.gw_storage) ||
             !isfinite(model->gw_reservoir.storage_max_m) ||
@@ -2280,6 +2278,7 @@ static int Set_value_at_indices (Bmi *self, const char *name, int * inds, int le
 
 }
 
+
 static int Set_value (Bmi *self, const char *name, void *src)
 {
     // serialization
@@ -2313,10 +2312,22 @@ static int Set_value (Bmi *self, const char *name, void *src)
     memcpy (dest, src, nbytes);
 
     if (strcmp (name, "maxsmc") == 0 || strcmp (name, "alpha_fc") == 0 || strcmp (name, "wltsmc") == 0 || strcmp (name, "maxsmc") == 0 || strcmp (name, "b") == 0 || strcmp (name, "slope") == 0 || strcmp (name, "satpsi") == 0 || strcmp (name, "Klf") == 0  || strcmp (name, "satdk") == 0){
-        init_soil_reservoir((cfe_state_struct*) self->data);
+
+        cfe_state_struct* cfe_ptr = (cfe_state_struct *) self->data;
+        init_soil_reservoir(cfe_ptr);
+    }
+    if (strcmp (name, "refkdt") == 0 || strcmp (name, "satdk") == 0){
+        cfe_state_struct* cfe_ptr = (cfe_state_struct *) self->data;
+        cfe_ptr->infiltration_excess_params_struct.Schaake_adjusted_magic_constant_by_soil_type = cfe_ptr->NWM_soil_params.refkdt * cfe_ptr->NWM_soil_params.satdk / 0.000002;
+
     }
 
-    return Set_value_at_indices(self, name, inds, 1, src);
+    if (strcmp (name, "storage_max_m") == 0) {
+         cfe_state_struct* cfe_ptr = (cfe_state_struct *) self->data;
+         cfe_ptr->gw_reservoir.storage_m = cfe_ptr->gw_reservoir.gw_storage * cfe_ptr->gw_reservoir.storage_max_m;
+     }
+    
+    return BMI_SUCCESS;
 }
 
 static int Get_component_name (Bmi *self, char * name)

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -2315,27 +2315,28 @@ static int Set_value (Bmi *self, const char *name, void *src)
     if (self->get_var_nbytes(self, name, &nbytes) == BMI_FAILURE)
         return BMI_FAILURE;
 
+    if (strcmp(name, "water_potential_evaporation_flux") == 0) {
+        double potential_et_m_per_s = *((double*)src);
+
+        if (!isfinite(potential_et_m_per_s) ||
+            potential_et_m_per_s < 0.0) {
+            Log(FATAL,
+                "Invalid water_potential_evaporation_flux passed to CFE Set_value: %lf. "
+                "PET forcing must be finite and non-negative. Aborting...\n",
+                potential_et_m_per_s);
+
+            return BMI_FAILURE;
+        }
+    }
+
     memcpy (dest, src, nbytes);
 
     if (strcmp (name, "maxsmc") == 0 || strcmp (name, "alpha_fc") == 0 || strcmp (name, "wltsmc") == 0 || strcmp (name, "maxsmc") == 0 || strcmp (name, "b") == 0 || strcmp (name, "slope") == 0 || strcmp (name, "satpsi") == 0 || strcmp (name, "Klf") == 0  || strcmp (name, "satdk") == 0){
-
-        cfe_state_struct* cfe_ptr = (cfe_state_struct *) self->data;
-        init_soil_reservoir(cfe_ptr);
-    }
-    if (strcmp (name, "refkdt") == 0 || strcmp (name, "satdk") == 0){
-        cfe_state_struct* cfe_ptr = (cfe_state_struct *) self->data;
-        cfe_ptr->infiltration_excess_params_struct.Schaake_adjusted_magic_constant_by_soil_type = cfe_ptr->NWM_soil_params.refkdt * cfe_ptr->NWM_soil_params.satdk / 0.000002;
-
+        init_soil_reservoir((cfe_state_struct*) self->data);
     }
 
-    if (strcmp (name, "storage_max_m") == 0) {
-         cfe_state_struct* cfe_ptr = (cfe_state_struct *) self->data;
-         cfe_ptr->gw_reservoir.storage_m = cfe_ptr->gw_reservoir.gw_storage * cfe_ptr->gw_reservoir.storage_max_m;
-     }
-    
-    return BMI_SUCCESS;
+    return Set_value_at_indices(self, name, inds, 1, src);
 }
-
 
 static int Get_component_name (Bmi *self, char * name)
 {

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -999,7 +999,7 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
                     "Invalid CFE groundwater reservoir parameters from config. "
                     "gw_storage=%lf, max_gw_storage=%lf, Cgw=%lf, expon=%lf. "
                     "CFE cannot initialize groundwater reservoir with non-finite or physically invalid required values. "
-                    "Please check upstream parameter generation.\n",
+                    "Please check upstream parameter generation.",
                     model->gw_reservoir.gw_storage,
                     model->gw_reservoir.storage_max_m,
                     model->gw_reservoir.coeff_primary,
@@ -1010,7 +1010,7 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
             else if (gw_bad_param_warned == 1) {
                 Log(SEVERE,
                     "Invalid CFE groundwater reservoir parameters occurred again; "
-                    "further warnings suppressed.\n");
+                    "subsequent occurrences of this message will be suppressed.");
 
                 gw_bad_param_warned = 2;
             }

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -979,9 +980,36 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
         return BMI_FAILURE;
     }
     
-    // compute gw storage in meters	
+    // compute gw storage in meters
     if ((is_gw_storage_set == TRUE) && (is_gw_max_set == TRUE)) {
-        model->gw_reservoir.storage_m = model->gw_reservoir.gw_storage * model->gw_reservoir.storage_max_m;
+        if (!isfinite(model->gw_reservoir.gw_storage) ||
+            !isfinite(model->gw_reservoir.storage_max_m) ||
+            !isfinite(model->gw_reservoir.coeff_primary) ||
+            !isfinite(model->gw_reservoir.exponent_primary) ||
+            model->gw_reservoir.gw_storage < 0.0 ||
+            model->gw_reservoir.storage_max_m <= 0.0) {
+
+            Log(WARNING,
+                "Invalid CFE groundwater reservoir parameters from config; "
+                "disabling groundwater reservoir and setting DEEP_GW_TO_CHANNEL_FLUX to 0. "
+                "gw_storage=%lf, max_gw_storage=%lf, Cgw=%lf, expon=%lf. "
+                "This is likely an upstream NHF parameter-generation issue.\n",
+                model->gw_reservoir.gw_storage,
+                model->gw_reservoir.storage_max_m,
+                model->gw_reservoir.coeff_primary,
+                model->gw_reservoir.exponent_primary);
+
+            model->gw_reservoir.gw_storage = 0.0;
+            model->gw_reservoir.storage_max_m = 0.0;
+            model->gw_reservoir.storage_m = 0.0;
+            model->gw_reservoir.coeff_primary = 0.0;
+            model->gw_reservoir.exponent_primary = 1.0;
+        }
+        else {
+            model->gw_reservoir.storage_m =
+                model->gw_reservoir.gw_storage *
+                model->gw_reservoir.storage_max_m;
+        }
     }
 
     if (is_num_timesteps_set == FALSE && strcmp(model->forcing_file, "BMI")) {

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -90,7 +90,7 @@ extern void cfe(
     else if (potentialEtIssueWarned == 1) {
       Log(WARNING,
           "Invalid CFE potential ET input occurred again; "
-          "further warnings suppressed.\n");
+          "subsequent occurrences of this message will be suppressed.\n");
 
       potentialEtIssueWarned = 2;
     }

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -72,6 +72,29 @@ extern void cfe(
   //##################################################
   // partition rainfall using Schaake function
   //##################################################
+  static int potentialEtIssueWarned = 0;
+
+  if (!isfinite(evap_struct->potential_et_m_per_s) ||
+      evap_struct->potential_et_m_per_s < 0.0) {
+
+    if (potentialEtIssueWarned == 0) {
+      Log(WARNING,
+          "Invalid CFE potential ET input detected. "
+          "water_potential_evaporation_flux=%lf, time_step_size=%lf. "
+          "This indicates an upstream forcing/BMI provider issue.\n",
+          evap_struct->potential_et_m_per_s,
+          time_step_size);
+
+      potentialEtIssueWarned = 1;
+    }
+    else if (potentialEtIssueWarned == 1) {
+      Log(WARNING,
+          "Invalid CFE potential ET input occurred again; "
+          "further warnings suppressed.\n");
+
+      potentialEtIssueWarned = 2;
+    }
+  }
   evap_struct->potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
   evap_struct->reduced_potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
  

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -72,34 +72,6 @@ extern void cfe(
   //##################################################
   // partition rainfall using Schaake function
   //##################################################
-
-  static int potentialEtIssueWarned = 0;
-
-  if (!isfinite(evap_struct->potential_et_m_per_s) ||
-      evap_struct->potential_et_m_per_s < 0.0) {
-
-    if (potentialEtIssueWarned == 0) {
-      Log(WARNING,
-          "Invalid CFE potential ET input received; using zero PET for this timestep "
-          "to prevent NaN propagation. "
-          "water_potential_evaporation_flux=%lf, time_step_size=%lf. "
-          "This indicates an upstream forcing/BMI provider issue that should be corrected.\n",
-          evap_struct->potential_et_m_per_s,
-          time_step_size);
-
-      potentialEtIssueWarned = 1;
-    }
-    else if (potentialEtIssueWarned == 1) {
-      Log(WARNING,
-          "Invalid CFE potential ET input occurred again; "
-          "further warnings suppressed.\n");
-
-      potentialEtIssueWarned = 2;
-    }
-
-    evap_struct->potential_et_m_per_s = 0.0;
-  }
-
   evap_struct->potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
   evap_struct->reduced_potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
  

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -73,16 +73,17 @@ extern void cfe(
   // partition rainfall using Schaake function
   //##################################################
 
-    static int potentialEtIssueWarned = 0;
+  static int potentialEtIssueWarned = 0;
 
-    if (!isfinite(evap_struct->potential_et_m_per_s) ||
+  if (!isfinite(evap_struct->potential_et_m_per_s) ||
       evap_struct->potential_et_m_per_s < 0.0) {
 
     if (potentialEtIssueWarned == 0) {
       Log(WARNING,
-          "Invalid CFE potential ET input; setting POTENTIAL_ET to 0. "
+          "Invalid CFE potential ET input received; using zero PET for this timestep "
+          "to prevent NaN propagation. "
           "water_potential_evaporation_flux=%lf, time_step_size=%lf. "
-          "This is likely an upstream forcing/BMI provider issue.\n",
+          "This indicates an upstream forcing/BMI provider issue that should be corrected.\n",
           evap_struct->potential_et_m_per_s,
           time_step_size);
 
@@ -98,6 +99,7 @@ extern void cfe(
 
     evap_struct->potential_et_m_per_s = 0.0;
   }
+
   evap_struct->potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
   evap_struct->reduced_potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
  

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -73,6 +73,31 @@ extern void cfe(
   // partition rainfall using Schaake function
   //##################################################
 
+    static int potentialEtIssueWarned = 0;
+
+    if (!isfinite(evap_struct->potential_et_m_per_s) ||
+      evap_struct->potential_et_m_per_s < 0.0) {
+
+    if (potentialEtIssueWarned == 0) {
+      Log(WARNING,
+          "Invalid CFE potential ET input; setting POTENTIAL_ET to 0. "
+          "water_potential_evaporation_flux=%lf, time_step_size=%lf. "
+          "This is likely an upstream forcing/BMI provider issue.\n",
+          evap_struct->potential_et_m_per_s,
+          time_step_size);
+
+      potentialEtIssueWarned = 1;
+    }
+    else if (potentialEtIssueWarned == 1) {
+      Log(WARNING,
+          "Invalid CFE potential ET input occurred again; "
+          "further warnings suppressed.\n");
+
+      potentialEtIssueWarned = 2;
+    }
+
+    evap_struct->potential_et_m_per_s = 0.0;
+  }
   evap_struct->potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
   evap_struct->reduced_potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
  

--- a/src/conceptual_reservoir.c
+++ b/src/conceptual_reservoir.c
@@ -1,7 +1,6 @@
 #ifndef _CONCEPTUAL_RESERVOIR_C
 #define _CONCEPTUAL_RESERVOIR_C
 
-#include <math.h>
 #include "logger.h"
 #include "conceptual_reservoir.h"
 
@@ -56,28 +55,23 @@ extern void conceptual_reservoir_flux_calc(struct conceptual_reservoir *da_reser
         da_reservoir->storage_max_m <= 0.0) {
 
       if (gw_bad_state_warned == 0) {
-          Log(WARNING,
-              "Invalid CFE groundwater reservoir state or parameters; "
-              "setting DEEP_GW_TO_CHANNEL_FLUX to 0. "
-              "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf.\n",
-              da_reservoir->storage_m,
-              da_reservoir->storage_max_m,
-              da_reservoir->coeff_primary,
-              da_reservoir->exponent_primary);
+        Log(WARNING,
+            "Invalid CFE groundwater reservoir state or parameters during flux calculation; "
+            "returning zero groundwater flux for this timestep. "
+            "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf.\n",
+            da_reservoir->storage_m,
+            da_reservoir->storage_max_m,
+            da_reservoir->coeff_primary,
+            da_reservoir->exponent_primary);
 
-          gw_bad_state_warned = 1;
+        gw_bad_state_warned = 1;
       }
       else if (gw_bad_state_warned == 1) {
-          Log(WARNING,
-              "Invalid CFE groundwater reservoir state or parameters occurred again; "
-              "further warnings suppressed.\n");
+        Log(WARNING,
+            "Invalid CFE groundwater reservoir state or parameters occurred again; "
+            "further warnings suppressed.\n");
 
-          gw_bad_state_warned = 2;
-      }
-
-      if (!isfinite(da_reservoir->storage_m) ||
-          da_reservoir->storage_m < 0.0) {
-        da_reservoir->storage_m = 0.0;
+        gw_bad_state_warned = 2;
       }
 
       return;
@@ -88,15 +82,28 @@ extern void conceptual_reservoir_flux_calc(struct conceptual_reservoir *da_reser
     double calculated_flux_m = da_reservoir->coeff_primary * (exp_term - 1.0);
 
     if (!isfinite(calculated_flux_m) || calculated_flux_m < 0.0) {
-      Log(WARNING,
-          "Invalid CFE groundwater flux calculation; "
-          "setting DEEP_GW_TO_CHANNEL_FLUX to 0. "
-          "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf, raw_flux=%lf.\n",
-          da_reservoir->storage_m,
-          da_reservoir->storage_max_m,
-          da_reservoir->coeff_primary,
-          da_reservoir->exponent_primary,
-          calculated_flux_m);
+      static int gw_bad_flux_warned = 0;
+
+      if (gw_bad_flux_warned == 0) {
+        Log(WARNING,
+            "Invalid CFE groundwater flux calculation; "
+            "returning zero groundwater flux for this timestep. "
+            "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf, raw_flux=%lf.\n",
+            da_reservoir->storage_m,
+            da_reservoir->storage_max_m,
+            da_reservoir->coeff_primary,
+            da_reservoir->exponent_primary,
+            calculated_flux_m);
+
+        gw_bad_flux_warned = 1;
+      }
+      else if (gw_bad_flux_warned == 1) {
+        Log(WARNING,
+            "Invalid CFE groundwater flux calculation occurred again; "
+            "further warnings suppressed.\n");
+
+        gw_bad_flux_warned = 2;
+      }
 
       return;
     }

--- a/src/conceptual_reservoir.c
+++ b/src/conceptual_reservoir.c
@@ -58,7 +58,7 @@ extern void conceptual_reservoir_flux_calc(struct conceptual_reservoir *da_reser
         Log(WARNING,
             "Invalid CFE groundwater reservoir state or parameters during flux calculation; "
             "returning zero groundwater flux for this timestep. "
-            "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf.\n",
+            "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf.",
             da_reservoir->storage_m,
             da_reservoir->storage_max_m,
             da_reservoir->coeff_primary,
@@ -69,7 +69,7 @@ extern void conceptual_reservoir_flux_calc(struct conceptual_reservoir *da_reser
       else if (gw_bad_state_warned == 1) {
         Log(WARNING,
             "Invalid CFE groundwater reservoir state or parameters occurred again; "
-            "further warnings suppressed.\n");
+            "subsequent occurrences of this message will be suppressed.");
 
         gw_bad_state_warned = 2;
       }
@@ -88,7 +88,7 @@ extern void conceptual_reservoir_flux_calc(struct conceptual_reservoir *da_reser
         Log(WARNING,
             "Invalid CFE groundwater flux calculation; "
             "returning zero groundwater flux for this timestep. "
-            "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf, raw_flux=%lf.\n",
+            "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf, raw_flux=%lf.",
             da_reservoir->storage_m,
             da_reservoir->storage_max_m,
             da_reservoir->coeff_primary,
@@ -100,7 +100,7 @@ extern void conceptual_reservoir_flux_calc(struct conceptual_reservoir *da_reser
       else if (gw_bad_flux_warned == 1) {
         Log(WARNING,
             "Invalid CFE groundwater flux calculation occurred again; "
-            "further warnings suppressed.\n");
+            "subsequent occurrences of this message will be suppressed.");
 
         gw_bad_flux_warned = 2;
       }

--- a/src/conceptual_reservoir.c
+++ b/src/conceptual_reservoir.c
@@ -42,9 +42,6 @@ extern void conceptual_reservoir_flux_calc(struct conceptual_reservoir *da_reser
   // ------------------ Conceptual Ground Water Reservoir -------------------------
   // single outlet reservoir like the NWM V1.2 exponential conceptual gw reservoir
   if (da_reservoir->is_exponential == TRUE) {
-    *primary_flux_m = 0.0;
-    *secondary_flux_m = 0.0;
-
     static int gw_bad_state_warned = 0;
 
     if (!isfinite(da_reservoir->storage_m) ||

--- a/src/conceptual_reservoir.c
+++ b/src/conceptual_reservoir.c
@@ -1,6 +1,8 @@
 #ifndef _CONCEPTUAL_RESERVOIR_C
 #define _CONCEPTUAL_RESERVOIR_C
 
+#include <math.h>
+#include "logger.h"
 #include "conceptual_reservoir.h"
 
 
@@ -40,20 +42,62 @@ extern void conceptual_reservoir_flux_calc(struct conceptual_reservoir *da_reser
   // *****************************************************************************
   // ------------------ Conceptual Ground Water Reservoir -------------------------
   // single outlet reservoir like the NWM V1.2 exponential conceptual gw reservoir
-  if (da_reservoir->is_exponential == TRUE) { 
+  if (da_reservoir->is_exponential == TRUE) {
+    *primary_flux_m = 0.0;
+    *secondary_flux_m = 0.0;
+
+    if (!isfinite(da_reservoir->storage_m) ||
+        !isfinite(da_reservoir->storage_max_m) ||
+        !isfinite(da_reservoir->coeff_primary) ||
+        !isfinite(da_reservoir->exponent_primary) ||
+        da_reservoir->storage_m <= 0.0 ||
+        da_reservoir->storage_max_m <= 0.0) {
+
+      Log(WARNING,
+          "Invalid CFE groundwater reservoir state or parameters; "
+          "setting DEEP_GW_TO_CHANNEL_FLUX to 0. "
+          "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf.\n",
+          da_reservoir->storage_m,
+          da_reservoir->storage_max_m,
+          da_reservoir->coeff_primary,
+          da_reservoir->exponent_primary);
+
+      if (!isfinite(da_reservoir->storage_m) ||
+          da_reservoir->storage_m < 0.0) {
+        da_reservoir->storage_m = 0.0;
+      }
+
+      return;
+    }
+
     // calculate the one flux and return.
     double exp_term = exp(da_reservoir->exponent_primary * da_reservoir->storage_m / da_reservoir->storage_max_m);
-    
-    *primary_flux_m = da_reservoir->coeff_primary * (exp_term - 1.0);
-    *secondary_flux_m = 0.0;
+    double calculated_flux_m = da_reservoir->coeff_primary * (exp_term - 1.0);
+
+    if (!isfinite(calculated_flux_m) || calculated_flux_m < 0.0) {
+      Log(WARNING,
+          "Invalid CFE groundwater flux calculation; "
+          "setting DEEP_GW_TO_CHANNEL_FLUX to 0. "
+          "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf, raw_flux=%lf.\n",
+          da_reservoir->storage_m,
+          da_reservoir->storage_max_m,
+          da_reservoir->coeff_primary,
+          da_reservoir->exponent_primary,
+          calculated_flux_m);
+
+      return;
+    }
+
+    *primary_flux_m = calculated_flux_m;
 
     // cap so flux never exceeds storage, but commented out here per OWP request (9/11/2025)
     //if (*primary_flux_m > da_reservoir->storage_m) {
     //    *primary_flux_m = da_reservoir->storage_m;
     //}
-    
+
     return;
   }
+
   // *****************************************************************************
   
   // code goes past here iff it is not a single outlet exponential deep groundwater reservoir of the NWM variety

--- a/src/conceptual_reservoir.c
+++ b/src/conceptual_reservoir.c
@@ -46,6 +46,8 @@ extern void conceptual_reservoir_flux_calc(struct conceptual_reservoir *da_reser
     *primary_flux_m = 0.0;
     *secondary_flux_m = 0.0;
 
+    static int gw_bad_state_warned = 0;
+
     if (!isfinite(da_reservoir->storage_m) ||
         !isfinite(da_reservoir->storage_max_m) ||
         !isfinite(da_reservoir->coeff_primary) ||
@@ -53,14 +55,25 @@ extern void conceptual_reservoir_flux_calc(struct conceptual_reservoir *da_reser
         da_reservoir->storage_m <= 0.0 ||
         da_reservoir->storage_max_m <= 0.0) {
 
-      Log(WARNING,
-          "Invalid CFE groundwater reservoir state or parameters; "
-          "setting DEEP_GW_TO_CHANNEL_FLUX to 0. "
-          "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf.\n",
-          da_reservoir->storage_m,
-          da_reservoir->storage_max_m,
-          da_reservoir->coeff_primary,
-          da_reservoir->exponent_primary);
+      if (gw_bad_state_warned == 0) {
+          Log(WARNING,
+              "Invalid CFE groundwater reservoir state or parameters; "
+              "setting DEEP_GW_TO_CHANNEL_FLUX to 0. "
+              "storage_m=%lf, storage_max_m=%lf, Cgw=%lf, expon=%lf.\n",
+              da_reservoir->storage_m,
+              da_reservoir->storage_max_m,
+              da_reservoir->coeff_primary,
+              da_reservoir->exponent_primary);
+
+          gw_bad_state_warned = 1;
+      }
+      else if (gw_bad_state_warned == 1) {
+          Log(WARNING,
+              "Invalid CFE groundwater reservoir state or parameters occurred again; "
+              "further warnings suppressed.\n");
+
+          gw_bad_state_warned = 2;
+      }
 
       if (!isfinite(da_reservoir->storage_m) ||
           da_reservoir->storage_m < 0.0) {


### PR DESCRIPTION

https://jira.nextgenwaterprediction.com/browse/NGWPC-10660

The issue involved invalid upstream groundwater and PET inputs propagating into the CFE model and producing `NaN` values in outputs such as `POTENTIAL_ET`, `GW_STORAGE`, `DEEP_GW_TO_CHANNEL_FLUX`, and `Q_OUT`. Investigation showed that the root cause was not the CFE physics itself, but invalid forcing and parameter values being passed into CFE from upstream workflows and parameter generation.

The fix focused on improving diagnostics and preventing unstable groundwater flux calculations while preserving the original invalid values for debugging and scientific transparency. Warning logs were added for:

* invalid groundwater reservoir configuration values during initialization,
* invalid groundwater reservoir state/parameter values during runtime flux calculations,
* and invalid PET forcing values.

The warnings were implemented using throttled logging to avoid excessive duplicate messages while still clearly exposing the issue in the EWTS logs. The implementation was carefully updated so that invalid values are logged but not overwritten or silently replaced with defaults. As a result:

* `POTENTIAL_ET` and `GW_STORAGE` remain `NaN` when upstream inputs are invalid,
* groundwater flux calculations safely return zero flux for that timestep to prevent unstable numerical propagation into `Q_OUT`,
* and the simulation continues running while preserving visibility of the underlying upstream issue.

Final validation confirmed that the EWTS logs now contain the expected warning messages for invalid PET forcing and invalid groundwater reservoir states/configuration, including duplicate-warning suppression behavior.
