### PR TITLE
Remove using generic EWTS_ID

### DIFF
--- a/include/logger.h
+++ b/include/logger.h
@@ -2,8 +2,12 @@
 #define CFE_LOGGER_H
 
 #include "ewts/module_constants.h"
-#define EWTS_ID EWTS_ID_CFE
 #include "ewts/logger.h"
 #include "ewts/log_levels.h"
+
+#define Log(level, ...) EwtsLogModule(EWTS_ID_CFE, (level), __VA_ARGS__)
+#define LOG(level, ...) EwtsLogModule(EWTS_ID_CFE, (level), __VA_ARGS__)
+#define GetLogLevel() EwtsGetLogLevelModule(EWTS_ID_CFE)
+#define IsLoggingEnabled() EwtsIsLoggingEnabledModule(EWTS_ID_CFE)
 
 #endif // CFE_LOGGER_H


### PR DESCRIPTION
Remove using generic EWTS_ID causing log messages to be incorrectly identified in the logs.