### PR TITLE
Exclude or include or EWTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+# cfe/MakeLists.txt
+
 cmake_minimum_required(VERSION 3.10)
 
 string(ASCII 27 Esc)

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,13 +1,117 @@
 #ifndef CFE_LOGGER_H
 #define CFE_LOGGER_H
 
+#ifdef CFE_USE_EWTS
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+// Using EWTS
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 #include "ewts/module_constants.h"
 #include "ewts/logger.h"
 #include "ewts/log_levels.h"
 
-#define Log(level, ...) EwtsLogModule(EWTS_ID_CFE, (level), __VA_ARGS__)
-#define LOG(level, ...) EwtsLogModule(EWTS_ID_CFE, (level), __VA_ARGS__)
-#define GetLogLevel() EwtsGetLogLevelModule(EWTS_ID_CFE)
-#define IsLoggingEnabled() EwtsIsLoggingEnabledModule(EWTS_ID_CFE)
+#define CFE_MODULE_ID EWTS_ID_CFE
 
+#define Log(level, ...) EwtsLogModule(CFE_MODULE_ID, (level), __VA_ARGS__)
+#define LOG(level, ...) EwtsLogModule(CFE_MODULE_ID, (level), __VA_ARGS__)
+#define GetLogLevel() EwtsGetLogLevelModule(CFE_MODULE_ID)
+#define IsLoggingEnabled() EwtsIsLoggingEnabledModule(CFE_MODULE_ID)
+
+#else
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+// Log messages written to STDOUT
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define CFE_MODULE_ID "CFE"
+typedef enum {
+    NOTSET  = 0,
+    DEBUG   = 10,
+    PERFORM = 15,
+    INFO    = 20,
+    WARNING = 30,
+    SEVERE  = 40,
+    FATAL   = 50
+} LogLevel;
+
+#define CFE_FALLBACK_LOGGING_ENABLED   1
+#define CFE_FALLBACK_LOG_LEVEL         INFO
+
+static inline bool IsLoggingEnabled(void) {
+    return CFE_FALLBACK_LOGGING_ENABLED;
+}
+
+static inline LogLevel GetLogLevel(void) {
+    return CFE_FALLBACK_LOG_LEVEL;
+}
+
+static inline const char* cfe_level_to_string(LogLevel level) {
+    switch (level) {
+        case DEBUG:   return "DEBUG";
+        case PERFORM: return "PERFORM";
+        case INFO:    return "INFO";
+        case WARNING: return "WARN";
+        case SEVERE:  return "ERROR";
+        case FATAL:   return "FATAL";
+        default:      return "LOG";
+    }
+}
+
+static inline void cfe_utc_timestamp(char* buffer, size_t size) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+
+    struct tm tm_utc;
+    gmtime_r(&tv.tv_sec, &tm_utc);
+
+    char base[32];
+    strftime(base, sizeof(base), "%Y-%m-%dT%H:%M:%S", &tm_utc);
+
+    snprintf(buffer, size, "%s.%03ldZ", base, tv.tv_usec / 1000);
+}
+
+static inline void cfe_strip_trailing_newlines(char* s) {
+    if (!s) return;
+
+    size_t len = strlen(s);
+    while (len > 0 && (s[len - 1] == '\n' || s[len - 1] == '\r')) {
+        s[--len] = '\0';
+    }
+}
+
+static inline void Log(LogLevel level, const char* fmt, ...) {
+    if (!fmt) return;
+    if (!IsLoggingEnabled()) return;
+    if (level < GetLogLevel()) return;
+
+    char message[4096];
+
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(message, sizeof(message), fmt, args);
+    va_end(args);
+
+    cfe_strip_trailing_newlines(message);
+
+    char timestamp[64];
+    cfe_utc_timestamp(timestamp, sizeof(timestamp));
+
+    char line[8192];
+    snprintf(line, sizeof(line), "%s %s %s %s\n",
+             timestamp,
+             CFE_MODULE_ID,
+             cfe_level_to_string(level),
+             message);
+
+    fputs(line, stdout);
+    fflush(stdout);
+}
+
+#define LOG(level, ...) Log((level), __VA_ARGS__)
+#endif
 #endif // CFE_LOGGER_H

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1244,11 +1244,12 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
 static int Initialize (Bmi *self, const char *file)
 {
     // Initialize the Error, Warning and Trapping System
-	#ifdef USE_EWTS    
-	    EwtsInit(EWTS_ID_CFE, true);
-	#else
-	    EwtsInit(EWTS_ID_CFE, false);
-	#endif  
+#ifdef CFE_USE_EWTS    
+    #pragma message("cfe.bmi_cfe.Initialize: CFE_USE_EWTS ON")
+    EwtsInit(CFE_MODULE_ID, true);
+#else
+    #pragma message("cfe.bmi_cfe.Initialize: CFE_USE_EWTS OFF")
+#endif  
 
     // setup the logger
     Log(INFO, "In CFE Initialize()\n");     

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1244,7 +1244,7 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
 static int Initialize (Bmi *self, const char *file)
 {
     // Initialize the Error, Warning and Trapping System
-	#ifdef EWTS_HAVE_NGEN_BRIDGE    
+	#ifdef USE_EWTS    
 	    EwtsInit(EWTS_ID_CFE, true);
 	#else
 	    EwtsInit(EWTS_ID_CFE, false);


### PR DESCRIPTION
Exclude ewts when `CFE_USE_EWTS` preprocessor symbol is not defined. This symbol is set in the `ngen/extern/cfe/CMakeFiles.txt` based on the `USE_EWTS` symbol.

## Additions

- Added check for `CFE_USE_EWTS`. When defined initialize the ewts logger, otherwise fallback to stdout logging

## Removals

- Initializing the ewts logger when `USE_EWTS` is not defined. Log messages will be sent to stdout

## Changes

- Update cmake minimum required version to 3.10

## Testing

1. Tested with docker build command build argument `USE_EWTS` set `ON` 
2. Tested with docker build command build argument `USE_EWTS` set `OFF`
3. Tested with docker build command build argument `USE_EWTS` not set, which defaults to `ON`