### PR TITLE
Add BMI Output Variables to Save State (NGWPC-11588)

### DIFF
--- a/src/bmi_serialization.cxx
+++ b/src/bmi_serialization.cxx
@@ -97,6 +97,15 @@ void CfeSerializer::serialize(Archive& ar, const unsigned int version) {
         ar & make_array(state->runoff_queue_m_per_timestep, // giuh_convolution_integral
                         state->num_giuh_ordinates + 1); // config
     } 
+
+    // BMI output vars
+    ar & state->infiltration_excess_params_struct.surface_water_partitioning_scheme;
+    ar & state->aorc.precip_kg_per_m2;
+    ar & state->sfcrnoff_accum_m;
+    ar & state->catchment_area_m2;
+    ar & state->time_step_size;
+    ar & state->flux_from_deep_gw_to_chan_m3_per_s;
+
     /// state->nash_surface_params.runon_infiltration not used for input or GetValue
     // else if (state->surface_runoff_scheme == NASH_CASCADE) {
     //     ar & state->nash_surface_params.runon_infiltration;


### PR DESCRIPTION
Expand the values saved to include any variables exposed by the list of output variables. These were previously omitted to keep the state size small, but it could cause problems with loading hindcasting states.

## Additions

- Additional serialization for properties related to BMI output variables.

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
